### PR TITLE
Validate filters in controller tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby file: '.ruby-version'
 
-gem 'filterameter', '~> 0.8'
+# gem 'filterameter', '~> 0.8'
+gem 'filterameter', github: 'RockSolt/filterameter', branch: 'main'
 gem 'next_page'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/RockSolt/filterameter.git
+  revision: 36d9d47a2437bf65c0a38dbe3c7d30c1b832ab0a
+  branch: main
+  specs:
+    filterameter (0.9.0)
+      rails (>= 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -107,8 +115,6 @@ GEM
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
-    filterameter (0.9.0)
-      rails (>= 6.1)
     formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -324,7 +330,7 @@ DEPENDENCIES
   capybara
   csv (~> 3.3)
   debug
-  filterameter (~> 0.8)
+  filterameter!
   guard (~> 2.18.0)
   guard-minitest (~> 2.4.6)
   guard-rubocop (~> 1.5.0)

--- a/test/controllers/films_controller_test.rb
+++ b/test/controllers/films_controller_test.rb
@@ -7,6 +7,11 @@ class FilmsControllerTest < ActionDispatch::IntegrationTest
     @film = films(:one)
   end
 
+  test 'declarations' do
+    validator = FilmsController.declarations_validator
+    assert_predicate validator, :valid?, -> { validator.errors }
+  end
+
   test 'should get index' do
     get films_url
     assert_response :success

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -7,6 +7,11 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     @location = locations(:one)
   end
 
+  test 'declarations' do
+    validator = LocationsController.declarations_validator
+    assert_predicate validator, :valid?, -> { validator.errors }
+  end
+
   test 'should get index' do
     get locations_url
     assert_response :success

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -7,6 +7,11 @@ class PeopleControllerTest < ActionDispatch::IntegrationTest
     @person = people(:one)
   end
 
+  test 'declarations' do
+    validator = PeopleController.declarations_validator
+    assert_predicate validator, :valid?, -> { validator.errors }
+  end
+
   test 'should get index' do
     get people_url
     assert_response :success


### PR DESCRIPTION
This switches Filterameter to main (rather than the latest release) to pull in the filter declaration validations.