### PR TITLE
Sort films

### DIFF
--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -10,6 +10,9 @@ class FilmsController < ApplicationController
   filter :writer_id, name: :written_by
   filter :actor_id, name: :acted_by
 
+  sort :release_year
+  default_sort release_year: :asc
+
   EAGER_LOADS_FOR_INDEX = [:production_company, :distributor,
                            { film_locations: :location,
                              directing_credits: :person,
@@ -80,7 +83,10 @@ class FilmsController < ApplicationController
   end
 
   def build_filter_chips
-    @filter_chips = params.to_unsafe_h.fetch(:filter, []).map do |field_name, value|
+    @filter_chips = params.to_unsafe_h
+                          .fetch(:filter, {})
+                          .except(:sort)
+                          .map do |field_name, value|
       Filter.factory(field_name, value)
     end
   end

--- a/app/javascript/controllers/submit_controller.js
+++ b/app/javascript/controllers/submit_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit(_event) {
+    this.element.form.requestSubmit()
+  }
+}

--- a/app/views/films/index.html.erb
+++ b/app/views/films/index.html.erb
@@ -5,7 +5,6 @@
 
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Films</h1>
-    <%= link_to 'New film', new_film_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 
   <div class="my-3"

--- a/app/views/films/index.html.erb
+++ b/app/views/films/index.html.erb
@@ -15,14 +15,31 @@
     <div class="my-3" data-quicksearch-target="searchInput"></div>
   </div>
 
-  <div>
-    <%= form_with url: films_path, scope: :filter,
+  <%= form_with url: films_path, scope: :filter,
                                    method: :get,
                                    data: { controller: "filter",
                                            action: "autocompleteSelection@document->filter#add" } do |form| %>
-      <%= render @filter_chips, form: form %>
-    <% end %>
-  </div>
+    <div class="flex flex-row">
+
+      <div>
+        <%= render @filter_chips, form: form %>
+      </div>
+
+      <div class="ml-auto flex">
+        <%= label_tag 'filter[sort]', 'Sort By: ', class: 'self-center mr-1' %>
+        <%= select_tag 'filter[sort]', 
+          options_for_select({ 'Newest first' => '-release_year',
+                              'Oldest first' => 'release_year',
+                              'Film name' => 'name' },
+                             params.dig('filter', 'sort') || 'release_year'),
+            class: 'bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500',
+            data: { controller: 'submit',
+                  action: 'submit#submit' } %>
+      </div>
+
+    </div>
+
+  <% end %>
 
   <%= render @films %>
   <%= paginate(@films, @query_params)%>

--- a/app/views/films/show.html.erb
+++ b/app/views/films/show.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full flex">
+<div class="mx-auto w-full flex">
   <div class="mx-auto">
     <% if notice.present? %>
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>

--- a/lib/tmdb/poster_client.rb
+++ b/lib/tmdb/poster_client.rb
@@ -11,7 +11,7 @@ module TMDB
   # TODO: Still needs a bit more error handling for when the movie is not found. For example, movie "Good
   # Neighbor Sam" has a typo in the name and is not found.
   class PosterClient
-    SEARCH_MOVIE_URL = 'https://api.themoviedb.org/3/search/movie'
+    SEARCH_MOVIE_URL = 'https://api.themoviedb.org/3/search/multi'
 
     def initialize(token, logger)
       @token = token

--- a/test/system/films_test.rb
+++ b/test/system/films_test.rb
@@ -12,20 +12,6 @@ class FilmsTest < ApplicationSystemTestCase
     assert_selector 'h1', text: 'Films'
   end
 
-  test 'should create film' do
-    visit films_url
-    click_on 'New film'
-
-    select @film.distributor.name, from: 'film_distributor_id'
-    fill_in 'Name', with: @film.name
-    select @film.production_company.name, from: 'film_production_company_id'
-    fill_in 'Release year', with: @film.release_year
-    click_on 'Create Film'
-
-    assert_text 'Film was successfully created'
-    click_on 'Back'
-  end
-
   test 'should update Film' do
     visit film_url(@film)
     click_on 'Edit this film', match: :first


### PR DESCRIPTION
Allow films to be sorted by release year and name.

This also includes a fix for TV show posters. The lookup was only searching movies, so it would error on TV shows.