### PR TITLE
Handle missing posters

### DIFF
--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -2,6 +2,9 @@
 
 # Model Poster caches the poster filename from TMDB.
 class Poster < ApplicationRecord
+  # ABX, CC BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0>, via Wikimedia Commons
+  NOT_FOUND_URL = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/P_Movie.svg'
+
   belongs_to :film
 
   class << self
@@ -14,7 +17,7 @@ class Poster < ApplicationRecord
 
     def lookup_and_create(film_id)
       film = Film.find(film_id)
-      filename = poster_client.for_movie(film.name, film.release_year)
+      filename = poster_client.for_movie(film.name, film.release_year).presence || NOT_FOUND_URL
       film.create_poster!(filename: filename)
     end
 
@@ -25,6 +28,8 @@ class Poster < ApplicationRecord
   end
 
   def url
+    return filename if filename == NOT_FOUND_URL
+
     "https://image.tmdb.org/t/p/w500#{filename}"
   end
 end

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -4,17 +4,24 @@
 class Poster < ApplicationRecord
   belongs_to :film
 
-  def self.for_film(film_id)
-    Poster.find_by(film_id: film_id) ||
-      lookup_and_create(film_id)
-  end
+  class << self
+    def for_film(film_id)
+      Poster.find_by(film_id: film_id) ||
+        lookup_and_create(film_id)
+    end
 
-  def self.lookup_and_create(film_id)
-    film = Film.find(film_id)
-    filename = TMDB::PosterClient.new(Rails.application.config.settings.tmdb_api_read_access_token,
-                                      Rails.logger)
-                                 .for_movie(film.name, film.release_year)
-    film.create_poster!(filename: filename)
+    private
+
+    def lookup_and_create(film_id)
+      film = Film.find(film_id)
+      filename = poster_client.for_movie(film.name, film.release_year)
+      film.create_poster!(filename: filename)
+    end
+
+    def poster_client
+      @poster_client ||= TMDB::PosterClient.new(Rails.application.config.settings.tmdb_api_read_access_token,
+                                                Rails.logger)
+    end
   end
 
   def url

--- a/lib/tmdb/poster_client.rb
+++ b/lib/tmdb/poster_client.rb
@@ -11,7 +11,7 @@ module TMDB
   # TODO: Still needs a bit more error handling for when the movie is not found. For example, movie "Good
   # Neighbor Sam" has a typo in the name and is not found.
   class PosterClient
-    SEARCH_MOVIE_URL = 'https://api.themoviedb.org/3/search/multi'
+    SEARCH_MOVIE_URL = 'https://api.themoviedb.org/3/search/movie'
 
     def initialize(token, logger)
       @token = token
@@ -22,7 +22,7 @@ module TMDB
       @logger.info "[#{self.class.name}] Calling TMDB for #{name} (#{release_year})"
 
       results = fetch_movie(name, release_year).presence || fetch_movie(name)
-      results.first['poster_path']
+      results.first['poster_path'] unless results.empty?
     end
 
     private

--- a/test/fixtures/films.yml
+++ b/test/fixtures/films.yml
@@ -11,3 +11,9 @@ two:
   release_year: 1
   production_company: two
   distributor: two
+
+no_poster:
+  name: Film Without a Poster
+  release_year: 1989
+  production_company: two
+  distributor: two

--- a/test/models/poster_test.rb
+++ b/test/models/poster_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'minitest/mock'
 
 module Films
   class PosterTest < ActiveSupport::TestCase

--- a/test/models/poster_test.rb
+++ b/test/models/poster_test.rb
@@ -20,11 +20,22 @@ module Films
       assert_mock pcm
     end
 
+    def test_for_film_when_poster_not_found
+      film = films(:no_poster)
+      pcm = poster_client_mock(film.name, film.release_year, poster_path: '')
+      Poster.stub :poster_client, pcm do
+        poster = Poster.for_film(film.id)
+        assert_equal Poster::NOT_FOUND_URL, poster.filename
+      end
+
+      assert_mock pcm
+    end
+
     private
 
-    def poster_client_mock(name, release_year)
+    def poster_client_mock(name, release_year, poster_path: '/the_poster')
       mock = Minitest::Mock.new
-      mock.expect :for_movie, '/the_poster', [name, release_year]
+      mock.expect :for_movie, poster_path, [name, release_year]
       mock
     end
   end

--- a/test/models/poster_test.rb
+++ b/test/models/poster_test.rb
@@ -4,8 +4,28 @@ require 'test_helper'
 
 module Films
   class PosterTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    def test_for_film_with_poster
+      film = films(:one)
+      assert_equal film.poster, Poster.for_film(film.id)
+    end
+
+    def test_for_film_without_poster_calls_poster_client_for_movie
+      film = films(:no_poster)
+      pcm = poster_client_mock(film.name, film.release_year)
+      Poster.stub :poster_client, pcm do
+        poster = Poster.for_film(film.id)
+        assert_equal '/the_poster', poster.filename
+      end
+
+      assert_mock pcm
+    end
+
+    private
+
+    def poster_client_mock(name, release_year)
+      mock = Minitest::Mock.new
+      mock.expect :for_movie, '/the_poster', [name, release_year]
+      mock
+    end
   end
 end


### PR DESCRIPTION
If no poster is found (which is the case for TV shows), just show a generic film image.