### PR TITLE
Add quick search to locations

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,12 +4,17 @@ class LocationsController < ApplicationController
   before_action :set_location, only: %i[show edit update destroy]
 
   filter :name, partial: true
+  filter :film_id, association: :film_locations
 
   # GET /locations
   def index
-    @locations = build_query_from_filters
+    @locations = build_query_from_filters(Location.includes(film_locations: :film))
     respond_to do |format|
-      format.html
+      format.html do
+        @query_params = params.to_unsafe_h.slice('filter', 'page')
+        build_filter_chips
+      end
+
       format.json { render json: @locations.limit(page_limit), only: %i[id name] }
     end
   end
@@ -61,5 +66,14 @@ class LocationsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def location_params
     params.require(:location).permit(:name, :find_neighborhood_id, :analysis_neighborhood_id, :supervisor_district_id)
+  end
+
+  def build_filter_chips
+    @filter_chips = params.to_unsafe_h
+                          .fetch(:filter, {})
+                          .except(:sort)
+                          .map do |field_name, value|
+      Filter.factory(field_name, value)
+    end
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -22,24 +22,8 @@ class LocationsController < ApplicationController
   # GET /locations/1
   def show; end
 
-  # GET /locations/new
-  def new
-    @location = Location.new
-  end
-
   # GET /locations/1/edit
   def edit; end
-
-  # POST /locations
-  def create
-    @location = Location.new(location_params)
-
-    if @location.save
-      redirect_to @location, notice: 'Location was successfully created.'
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
 
   # PATCH/PUT /locations/1
   def update

--- a/app/javascript/src/search_sources.js
+++ b/app/javascript/src/search_sources.js
@@ -89,6 +89,17 @@ export class FilmsSource extends SearchSource {
 
   templates = {
     header() {
+      return 'Filter by film';
+    },
+    item({ item }) {
+      return `${item.name}`
+    }
+  }
+}
+
+export class FilmsJumpToSource extends FilmsSource {
+  templates = {
+    header() {
       return 'Jump to...';
     },
     item({ item, html }) {
@@ -98,7 +109,6 @@ export class FilmsSource extends SearchSource {
 
   onSelect() { }
 }
-
 export class LocationsSource extends SearchSource {
   powerSearchCode = "L"
 
@@ -113,6 +123,17 @@ export class LocationsSource extends SearchSource {
     },
     item({ item }) {
       return `${item.name}`
+    }
+  }
+}
+
+export class LocationsJumpToSource extends LocationsSource {
+  templates = {
+    header() {
+      return 'Jump to...'
+    },
+    item({ item, html }) {
+      return html`<a href="/locations/${item.id}">${item.name}</a>`
     }
   }
 }

--- a/app/views/films/index.html.erb
+++ b/app/views/films/index.html.erb
@@ -7,9 +7,8 @@
     <h1 class="font-bold text-4xl">Films</h1>
   </div>
 
-
   <%= quick_search({ name: 'NameContainsSource', 
-                     films: 'FilmsSource',
+                     films: 'FilmsJumpToSource',
                      location_id: 'LocationsSource',
                      director_id: 'DirectorsSource',
                      writer_id: 'WritersSource',
@@ -17,10 +16,11 @@
                    placeholder: 'Search for films',
                    class: 'my-3') %>
 
-  <%= form_with url: films_path, scope: :filter,
-                                   method: :get,
-                                   data: { controller: "filter",
-                                           action: "autocompleteSelection@document->filter#add" } do |form| %>
+  <%= form_with url: films_path, 
+                scope: :filter,
+                method: :get,
+                data: { controller: "filter",
+                        action: "autocompleteSelection@document->filter#add" } do |form| %>
     <div class="flex flex-row">
 
       <div>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -3,10 +3,25 @@
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
   <% end %>
 
-  <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Locations</h1>
-    <%= link_to 'New location', new_location_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
-  </div>
+  <h1 class="font-bold text-4xl">Locations</h1>
+
+  <%= quick_search({ name: 'NameContainsSource', 
+                     locations: 'LocationsJumpToSource',
+                     film_id: 'FilmsSource' },
+                   placeholder: 'Search for films',
+                   class: 'my-3') %>
+
+  <%= form_with url: locations_path, 
+                scope: :filter,
+                method: :get,
+                data: { controller: "filter",
+                        action: "autocompleteSelection@document->filter#add" } do |form| %>
+    <div class="flex flex-row">
+      <div>
+        <%= render @filter_chips, form: form %>
+      </div>
+    </div>
+  <% end %>
 
   <div id="locations" class="min-w-full">
     <%= render @locations %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -1,7 +1,0 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">New location</h1>
-
-  <%= render "form", location: @location %>
-
-  <%= link_to 'Back to locations', locations_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-</div>

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -17,23 +17,6 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should get new' do
-    get new_location_url
-    assert_response :success
-  end
-
-  test 'should create location' do
-    assert_difference('Location.count') do
-      post locations_url,
-           params: { location: { analysis_neighborhood_id: @location.analysis_neighborhood_id,
-                                 find_neighborhood_id: @location.find_neighborhood_id,
-                                 name: @location.name,
-                                 supervisor_district_id: @location.supervisor_district_id } }
-    end
-
-    assert_redirected_to location_url(Location.last)
-  end
-
   test 'should show location' do
     get location_url(@location)
     assert_response :success

--- a/test/system/locations_test.rb
+++ b/test/system/locations_test.rb
@@ -12,20 +12,6 @@ class LocationsTest < ApplicationSystemTestCase
     assert_selector 'h1', text: 'Locations'
   end
 
-  test 'should create location' do
-    visit locations_url
-    click_on 'New location'
-
-    fill_in 'Analysis neighborhood', with: @location.analysis_neighborhood_id
-    fill_in 'Find neighborhood', with: @location.find_neighborhood_id
-    fill_in 'Name', with: @location.name
-    fill_in 'Supervisor district', with: @location.supervisor_district_id
-    click_on 'Create Location'
-
-    assert_text 'Location was successfully created'
-    click_on 'Back'
-  end
-
   test 'should update Location' do
     visit location_url(@location)
     click_on 'Edit this location', match: :first


### PR DESCRIPTION
This called out that the Jump To source, if it includes links in the items, must be a separate source than a non-Jump To. If the redirect to the target were to be deferred to the handler, a single source could be used (though it would still need to be able to adjust the template header). It seems simpler to have two sources, which can share logic through inheritance.