### PR TITLE
Promote shared code to Application Controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,17 @@ class ApplicationController < ActionController::Base
   def page_limit
     params.fetch(:limit, 5)
   end
+
+  def build_pagination_query_params
+    params.to_unsafe_h.slice('filter', 'page')
+  end
+
+  def build_filter_chips
+    params.to_unsafe_h
+          .fetch(:filter, {})
+          .except(:sort)
+          .map do |field_name, value|
+      Filter.factory(field_name, value)
+    end
+  end
 end

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -27,8 +27,8 @@ class FilmsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @query_params = params.to_unsafe_h.slice('filter', 'page')
-        build_filter_chips
+        @query_params = build_pagination_query_params
+        @filter_chips = build_filter_chips
       end
       format.json { render json: @films, only: %i[id name release_year] }
     end
@@ -81,14 +81,5 @@ class FilmsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def film_params
     params.require(:film).permit(:name, :release_year, :production_company_id, :distributor_id)
-  end
-
-  def build_filter_chips
-    @filter_chips = params.to_unsafe_h
-                          .fetch(:filter, {})
-                          .except(:sort)
-                          .map do |field_name, value|
-      Filter.factory(field_name, value)
-    end
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -14,8 +14,8 @@ class LocationsController < ApplicationController
     @locations = paginate_resource(@locations)
     respond_to do |format|
       format.html do
-        @query_params = params.to_unsafe_h.slice('filter', 'page')
-        build_filter_chips
+        @query_params = build_pagination_query_params
+        @filter_chips = build_filter_chips
       end
 
       format.json { render json: @locations.limit(page_limit), only: %i[id name] }
@@ -53,14 +53,5 @@ class LocationsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def location_params
     params.require(:location).permit(:name, :find_neighborhood_id, :analysis_neighborhood_id, :supervisor_district_id)
-  end
-
-  def build_filter_chips
-    @filter_chips = params.to_unsafe_h
-                          .fetch(:filter, {})
-                          .except(:sort)
-                          .map do |field_name, value|
-      Filter.factory(field_name, value)
-    end
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -6,9 +6,12 @@ class LocationsController < ApplicationController
   filter :name, partial: true
   filter :film_id, association: :film_locations
 
+  paginate_with default_limit: 12
+
   # GET /locations
   def index
     @locations = build_query_from_filters(Location.includes(film_locations: :film))
+    @locations = paginate_resource(@locations)
     respond_to do |format|
       format.html do
         @query_params = params.to_unsafe_h.slice('filter', 'page')

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -26,4 +26,6 @@
   <div id="locations" class="min-w-full">
     <%= render @locations %>
   </div>
+
+  <%= paginate(@locations, @query_params)%>
 </div>


### PR DESCRIPTION
Move shared code for pagination and filter chips from Films and Locations controllers up to the Application controller.