### PR TITLE
Add hooks to override sources in Quick Search

### DIFF
--- a/app/javascript/controllers/quicksearch_controller.js
+++ b/app/javascript/controllers/quicksearch_controller.js
@@ -17,20 +17,32 @@ export default class extends Controller {
   }
 
   connect() {
-    // const sources = this.sourcesValue.map(source => new SearchSources[source](this))
-    const sources = this.buildSources()
+    const sources = this.buildSourcesFromSourceMapping()
+    this.instance = autocomplete(this.buildAutocompleteOptions(sources))
+  }
 
-    this.instance = autocomplete({
+  buildAutocompleteOptions(sources) {
+    return {
       container: this.searchInputTarget,
       placeholder: this.placeholderValue,
       autofocus: true,
       getSources() { return sources },
-    })
+    }
   }
 
-  buildSources() {
+  buildSourcesFromSourceMapping() {
     const callback = this.onSelect.bind(this)
-    return Object.entries(this.sourceMappingValue).map(([searchKey, source]) => new SearchSources[source](searchKey, callback))
+    return Object.entries(this.sourceMappingValue)
+                 .map(([searchKey, source]) => this.buildSource(searchKey, source, callback))
+  }
+
+  buildSource(searchKey, source, callback) {
+    const sourceClass = this.lookupSourceClass(source)
+    return new sourceClass(searchKey, callback)
+  }
+
+  lookupSourceClass(source){
+    return SearchSources[source]
   }
 
   disconnect() {

--- a/app/views/films/index.html.erb
+++ b/app/views/films/index.html.erb
@@ -7,7 +7,7 @@
     <h1 class="font-bold text-4xl">Films</h1>
   </div>
 
-  <%= quick_search({ name: 'NameContainsSource', 
+  <%= quick_search({ name: 'NameContainsSource',
                      films: 'FilmsJumpToSource',
                      location_id: 'LocationsSource',
                      director_id: 'DirectorsSource',


### PR DESCRIPTION
No functional changes here, just moving work out to methods that clarify as well as provide hooks to override at different levels.